### PR TITLE
fix: mark `indent_vec_new` static

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -43,7 +43,7 @@ typedef struct {
     uint16_t *data;
 } indent_vec;
 
-indent_vec indent_vec_new() {
+static indent_vec indent_vec_new() {
     indent_vec vec = VEC_NEW;
     vec.data = calloc(1, sizeof(uint16_t));
     vec.cap = 1;


### PR DESCRIPTION
Forgot this one little bit

Python and Pug both have a function named indent_vec_new, I fixed Python to be static, but this should be too so mislinking doesn't occur